### PR TITLE
Parse issuer from a different line

### DIFF
--- a/src/PassVeil/Store/Gpg.hs
+++ b/src/PassVeil/Store/Gpg.hs
@@ -323,12 +323,12 @@ verify' whoami path = do
 
     getIssuer input
       | "Good signature" `isInfixOf` input =
-        let fprPrefix = "Primary key fingerprint: "
-        in case filter (fprPrefix `isPrefixOf`) $ Text.lines input of
+        let usingKey i = "using" `isInfixOf` i && "key" `isInfixOf` i
+        in case filter usingKey $ Text.lines input of
           [] -> Nothing
           (fingerprintLine : _) ->
             let
-              k = last $ Text.splitOn ":" fingerprintLine
+              k = last $ Text.splitOn "key" fingerprintLine
               fpr = Text.filter (/= ' ') k
             in Just $ Fingerprint fpr
       | otherwise = Nothing


### PR DESCRIPTION
Problem: when verifying, we parse the gpg output, taking the issuer info from a like starting with "Primary key fingerprint". Turns out, not every even remotely recent gpg version outputs that line. Or maybe it's something in the config.

Solution: switched parsing to another line that will read "using `<scheme>` key `<fingerprint>`".